### PR TITLE
Add cURL example without bitrix24-php-sdk

### DIFF
--- a/php/quick-start/simple/01-curl-without-sdk/README.MD
+++ b/php/quick-start/simple/01-curl-without-sdk/README.MD
@@ -1,0 +1,8 @@
+# Work with cURL without bitrix24-php-sdk
+
+In this example we work with cURL without bitrix24-php-sdk
+At this level of abstraction, you will have to handle errors that will occur on your own.
+These are errors when working with the network, errors when working with Bitrix24.
+
+> [!WARNING]  
+> The example is added for educational purposes only, you should not use the code from this example in production.

--- a/php/quick-start/simple/01-curl-without-sdk/example.php
+++ b/php/quick-start/simple/01-curl-without-sdk/example.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * This file is part of the b24sdk-examples package.
+ *
+ * © Maksim Mesilov <mesilov.maxim@gmail.com>
+ *
+ * For the full copyright and license information, please view the MIT-LICENSE.txt
+ * file that was distributed with this source code.
+ */
+
+// In this example we work with cURL without bitrix24-php-sdk
+// At this level of abstraction, you will have to handle errors that will occur on your own.
+// These are errors when working with the network, errors when working with Bitrix24
+
+
+// Define variables
+$bitrix24WebhookURL = 'INSERT YOUR WEBHOOK URL HERE';
+
+// we call method crm.lead.add that's why we need add scope CRM in webhook settings
+$method = 'crm.lead.add';
+$postFields = [
+    'fields' => [
+        'TITLE' => 'New Lead from cURL',
+        'NAME' => 'John',
+        'LAST_NAME' => 'Doe',
+        'STATUS_ID' => 'NEW',
+        'OPENED' => 'Y',
+        'ASSIGNED_BY_ID' => 1,
+        'PHONE' => [
+            ['VALUE' => '+1234567890', 'VALUE_TYPE' => 'WORK']
+        ],
+        'EMAIL' => [
+            ['VALUE' => 'test@example.com', 'VALUE_TYPE' => 'WORK']
+        ]
+    ],
+    'params' => ['REGISTER_SONET_EVENT' => 'Y']
+];
+
+// Initialize cURL
+$curl = curl_init();
+
+// Set cURL options
+curl_setopt_array($curl, [
+    CURLOPT_URL => $bitrix24WebhookURL . $method,
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_POST => true,
+    CURLOPT_POSTFIELDS => http_build_query($postFields), // Convert data to URL-encoded query
+    CURLOPT_HTTPHEADER => [
+        'Content-Type: application/x-www-form-urlencoded'
+    ]
+]);
+
+// Execute request and fetch response
+$response = curl_exec($curl);
+
+// Check for errors
+if (curl_errno($curl)) {
+    echo 'Error: ' . curl_error($curl);
+} else {
+    // Decode response
+    $responseData = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+    print_r($responseData);
+}
+
+// Close cURL session
+curl_close($curl);

--- a/php/quick-start/simple/01-curl-without-sdk/example.php
+++ b/php/quick-start/simple/01-curl-without-sdk/example.php
@@ -38,6 +38,11 @@ $postFields = [
 ];
 
 // Initialize cURL
+if (!extension_loaded('curl')) {
+    print("fatal error: cURL is not available. Activete it or install it." . PHP_EOL);
+    exit();
+}
+
 $curl = curl_init();
 
 // Set cURL options


### PR DESCRIPTION
Introduce a basic example demonstrating how to use cURL to interact with Bitrix24 without relying on the bitrix24-php-sdk. This includes error handling, a sample API request to add a lead, and a README file explaining limitations and educational use.